### PR TITLE
Add difficulty selector for Minesweeper

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -1,9 +1,27 @@
 "use strict";
 var _a;
-const gridSize = 8;
-const mineCount = 10;
+let gridSize = 8;
+let mineCount = 10;
 let grid = [];
 const boardElement = document.getElementById('board');
+const difficultySelect = document.getElementById('difficulty');
+difficultySelect === null || difficultySelect === void 0 ? void 0 : difficultySelect.addEventListener('change', () => {
+    switch (difficultySelect.value) {
+        case 'easy':
+            gridSize = 8;
+            mineCount = 10;
+            break;
+        case 'medium':
+            gridSize = 12;
+            mineCount = 25;
+            break;
+        case 'hard':
+            gridSize = 16;
+            mineCount = 40;
+            break;
+    }
+    init();
+});
 function init() {
     grid = [];
     boardElement.innerHTML = '';

--- a/index.html
+++ b/index.html
@@ -7,6 +7,12 @@
 </head>
 <body>
   <h1>Minesweeper</h1>
+  <label for="difficulty">Schwierigkeit:</label>
+  <select id="difficulty">
+    <option value="easy">Leicht</option>
+    <option value="medium">Mittel</option>
+    <option value="hard">Schwer</option>
+  </select>
   <button id="reset">Reset</button>
   <div id="board"></div>
   <script src="dist/main.js"></script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
-const gridSize = 8;
-const mineCount = 10;
+let gridSize = 8;
+let mineCount = 10;
 
 interface Cell {
   element: HTMLDivElement;
@@ -11,6 +11,25 @@ interface Cell {
 
 let grid: Cell[][] = [];
 const boardElement = document.getElementById('board') as HTMLDivElement;
+const difficultySelect = document.getElementById('difficulty') as HTMLSelectElement | null;
+
+difficultySelect?.addEventListener('change', () => {
+  switch (difficultySelect.value) {
+    case 'easy':
+      gridSize = 8;
+      mineCount = 10;
+      break;
+    case 'medium':
+      gridSize = 12;
+      mineCount = 25;
+      break;
+    case 'hard':
+      gridSize = 16;
+      mineCount = 40;
+      break;
+  }
+  init();
+});
 
 function init() {
   grid = [];


### PR DESCRIPTION
## Summary
- allow selecting easy, medium, or hard difficulty
- adjust grid size and mine count when difficulty changes

## Testing
- `tsc`

------
https://chatgpt.com/codex/tasks/task_e_686f512c6d5c832ba6bf3932921c63c8